### PR TITLE
5 cran package check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     httr2,
     jsonlite,
     purrr,
+    tibble,
     tidyr
 Suggests:
     ggplot2,

--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ library(cvdprevent)
 ## basic example code
 cvd_indicator_list() |> 
   head(n = 4)
-#> # A tibble: 4 × 10
-#>   AxisCharacter DataUpdateInterval FormatDisplayName IndicatorCode
-#>   <chr>         <lgl>              <chr>             <chr>        
-#> 1 %             NA                 Proportion %      CVDP001AF    
-#> 2 %             NA                 Proportion %      CVDP002AF    
-#> 3 %             NA                 Proportion %      CVDP001HYP   
-#> 4 %             NA                 Proportion %      CVDP004HYP   
-#> # ℹ 6 more variables: IndicatorFormatID <int>, IndicatorID <int>,
-#> #   IndicatorName <chr>, IndicatorOrder <int>, IndicatorShortName <chr>,
-#> #   IndicatorStatus <chr>
+#> # A tibble: 4 × 12
+#>   AxisCharacter DataUpdateInterval FormatDisplayName HighestPriorityNotificati…¹
+#>   <chr>         <lgl>              <chr>             <chr>                      
+#> 1 %             NA                 Proportion %      <NA>                       
+#> 2 %             NA                 Proportion %      <NA>                       
+#> 3 %             NA                 Proportion %      <NA>                       
+#> 4 %             NA                 Proportion %      <NA>                       
+#> # ℹ abbreviated name: ¹​HighestPriorityNotificationType
+#> # ℹ 8 more variables: IndicatorCode <chr>, IndicatorFormatID <int>,
+#> #   IndicatorID <int>, IndicatorName <chr>, IndicatorOrder <int>,
+#> #   IndicatorShortName <chr>, IndicatorStatus <chr>, NotificationCount <int>
 ```
 
 See `vignette('using_cvdprevent', package = 'cvdprevent')` for more

--- a/man/cvd_indicator_nationalarea_metric_data.Rd
+++ b/man/cvd_indicator_nationalarea_metric_data.Rd
@@ -18,16 +18,26 @@ cvd_indicator_nationalarea_metric_data(
 \item{area_id}{integer - area for which to return data (compulsory)}
 }
 \value{
-Tibble of performance against the specified metric in the area as compared with national level
+List of named tibbles (\code{area}, \code{target}) where \code{target} is only provided if data is available.
 }
 \description{
-Returns national and area data for provided metric, area and time period.
-Target data contains the target value as a percentage stored as whole number
-up to 100; target patients is the number of patients more needed to reach
-the target percentage. If there is not data for both national and chosen
-area an error will be returned.
+Returns national and area data for the provided metric, area, and time period.
 }
 \details{
+The returned object is a list containing named tibbles. The two possible
+tibbles are:
+\itemize{
+\item \code{area}: contains metric data for the specified area in comparison with national metric data.
+\item \code{target}: contains details on how to reach target values, including:
+\itemize{
+\item target value as a percentage (stored as a whole number up to 100)
+\item target patients (the number of additional patients needed to reach the target percentage)
+}
+}
+
+Note that the \code{target} tibble is only provided if data is available for both
+national and the chosen area.
+
 CVD Prevent API documentation:
 \href{https://bmchealthdocs.atlassian.net/wiki/spaces/CP/pages/317882369/CVDPREVENT+API+Documentation#\%2Findicator\%2FnationalVsAreaMetricData\%2F\%3Cmetric_ID\%3E}{Indicator national vs area metric data}
 }
@@ -35,15 +45,29 @@ CVD Prevent API documentation:
 # Compare performance against metric 150  (AF: treatment with anticoagulants
 # - all people) in 'Chester South PCN' (area ID 553) with national
 # performance:
-cvd_indicator_nationalarea_metric_data(metric_id = 150, time_period_id = 17, area_id = 553) |>
-dplyr::slice_head(n=5)
+return_list <- cvd_indicator_nationalarea_metric_data(
+    metric_id = 150,
+    time_period_id = 17,
+    area_id = 553
+)
+
+# See what the list contains
+return_list |> summary()
+
+# Extract the `area` details
+area_data <- return_list$area
+area_data |> gt::gt()
+
+# Extract `target` details
+target_data <- return_list$target
+target_data |> gt::gt()
 }
 \seealso{
 \code{\link[=cvd_indicator_list]{cvd_indicator_list()}}, \code{\link[=cvd_indicator_metric_list]{cvd_indicator_metric_list()}}, \code{\link[=cvd_indicator]{cvd_indicator()}},
 \code{\link[=cvd_indicator_tags]{cvd_indicator_tags()}}, \code{\link[=cvd_indicator_details]{cvd_indicator_details()}}, \code{\link[=cvd_indicator_sibling]{cvd_indicator_sibling()}},
 \code{\link[=cvd_indicator_child_data]{cvd_indicator_child_data()}}, \code{\link[=cvd_indicator_data]{cvd_indicator_data()}}, \code{\link[=cvd_indicator_metric_data]{cvd_indicator_metric_data()}},
 \code{\link[=cvd_indicator_raw_data]{cvd_indicator_raw_data()}},
-\code{\link[=cvd_indicator_priority_groups]{cvd_indicator_priority_groups()}}, \code{\link[=cvd_indicator_pathway_group]{cvd_indicator_pathway_group()}}, #
+\code{\link[=cvd_indicator_priority_groups]{cvd_indicator_priority_groups()}}, \code{\link[=cvd_indicator_pathway_group]{cvd_indicator_pathway_group()}},
 \code{\link[=cvd_indicator_group]{cvd_indicator_group()}}, \code{\link[=cvd_indicator_metric_timeseries]{cvd_indicator_metric_timeseries()}},
 \code{\link[=cvd_indicator_person_timeseries]{cvd_indicator_person_timeseries()}}, \code{\link[=cvd_indicator_metric_systemlevel_comparison]{cvd_indicator_metric_systemlevel_comparison()}},
 \code{\link[=cvd_indicator_metric_area_breakdown]{cvd_indicator_metric_area_breakdown()}}

--- a/vignettes/using_cvdprevent.Rmd
+++ b/vignettes/using_cvdprevent.Rmd
@@ -420,12 +420,51 @@ cvd_indicator_raw_data(indicator_id = 7, time_period_id = 17, system_level_id = 
 
 To return metric data for a given area and time period along with national results to compare against use function `cvd_indicator_nationalarea_metric_data()`.
 
+The output is a list of named tibbles. The two possible tibbles are:
+
+-   `area`: contains metric data for the specified area in comparison with national metric data.
+
+-   `target`: contains details on how to reach target values, including:
+
+    -   target value as a percentage (stored as a whole number up to 100)
+
+    -   target patients (the number of additional patients needed to reach the target percentage)
+
+Note that the `target` tibble is only provided if data is available for both national and the chosen area.
+
 Here we compare performance against metric 150 (AF: treatment with anticoagulants - all people) in 'Chester South PCN' (area ID 553) with national performance:
 
 ```{r}
-cvd_indicator_nationalarea_metric_data(metric_id = 150, time_period_id = 17, area_id = 553) |> 
-  gt::gt()
+return_list <- cvd_indicator_nationalarea_metric_data(
+  metric_id = 150, 
+  time_period_id = 17, 
+  area_id = 553
+)
+
+return_list |> summary()
 ```
+
+### Area data
+
+We can extract the tibbles using the `list$object` notation. Here we extract the area metric comparison with national data:
+
+```{r}
+area_data <- return_list$area
+area_data |> gt::gt()
+```
+
+### Target data
+
+Here we extract the target details:
+
+```{r}
+target_data <- return_list$target
+target_data |> gt::gt()
+```
+
+`Target value` is a percentage figure indicating the national target for this metric. `Target patients` is the number of additional patients needed by Chester South PCN to reach the target value.
+
+NB, `target` data is only provided where there are data for both national and the specified area.
 
 ## List priority group indicators
 


### PR DESCRIPTION
closes #5 

### Fixes issue detected by CRAN package check

This PR fixes an issue highlighted by CRAN package check. The issue affected tests, example codes and vignettes and was traced to a single function `cvd_indicator_nationalarea_metric_data()`.

The cause was a change to the data returned by the API which returns up to two tibbles of data in the json file. When provided the second tibble contains details for the number of patients needed by the area to reach the metric target.

This PR contains changes to the function to handle up to two tibble outputs in a single named list object, as well as supporting documentation (manual and vignettes).