### PR TITLE
Release v0.2.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: cvdprevent
 Title: Access and Analyse Data from the 'CVD Prevent' API
-Version: 0.2.3.9000
+Version: 0.2.4
 Authors@R: c(
     person("Craig", "Parylo", , "craig.parylo2@nhs.net", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-4297-7808")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# cvdprevent (development version)
+# cvdprevent 0.2.4
 
 # Version 0.2.4 (2025-11-11)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # cvdprevent (development version)
 
+# Version 0.2.4 (2025-11-11)
+
+## Added
+- None in this release.
+
+## Changed
+- `cvd_clear_cache()` is exported for end-users to access, for example to clear stale values from the cache.
+
+## Fixed
+- Cache defaults to in-memory when the package is used non-interatively, which should resolve CRAN test issues on certain builds. When used interactively (most use-cases) will use persistent disc-based cache that is more convenient for users.
+
+## Deprecated
+- None in this release.
+
 # Version 0.2.3 (2025-11-05)
 
 ## Added

--- a/R/cvd_memoise.R
+++ b/R/cvd_memoise.R
@@ -41,8 +41,8 @@ m_cache <- if (is_persistent_cache_ok()) {
     max_age = 60 * 60 * 24 * 7 # 1 week in seconds
   )
 } else {
-  # otherwise use in-memory cache
-  memoise::cache_memory()
+  # otherwise use in-memory cache set to invalidate after 15 minutes
+  cachem::cache_mem(max_age = 60 * 15)
 }
 
 # Helper to memoise a lookup with the shared cache

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,7 +60,13 @@ pak::pak("cvdprevent")
 library(cvdprevent)
 
 # List all available indicators (first 4 shown)
-cvd_indicator_list() |> head(4)
+cvd_indicator_list(time_period_id = 22, system_level_id = 1) |>
+  dplyr::select(dplyr::any_of(c(
+    "IndicatorID",
+    "IndicatorCode",
+    "IndicatorShortName"
+  ))) |>
+  dplyr::slice_head(n = 4)
 ```
 
 Typical outputs are [tibble](https://tibble.tidyverse.org/)s, making them easy to filter and manipulate: 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,20 @@ pak::pak("cvdprevent")
 library(cvdprevent)
 
 # List all available indicators (first 4 shown)
-cvd_indicator_list() |> head(4)
-#> ✖ Validation error: time_period_id - time_period_id is required but missing
-#> # A tibble: 1 × 7
-#>   context           error          status url   params resp  timestamp          
-#>   <chr>             <chr>           <int> <chr> <chr>  <chr> <dttm>             
-#> 1 validate_input_id time_period_i…     NA <NA>  <NA>   <NA>  2025-11-05 19:46:25
+cvd_indicator_list(time_period_id = 22, system_level_id = 1) |>
+  dplyr::select(dplyr::any_of(c(
+    "IndicatorID",
+    "IndicatorCode",
+    "IndicatorShortName"
+  ))) |>
+  dplyr::slice_head(n = 4)
+#> # A tibble: 4 × 3
+#>   IndicatorID IndicatorCode IndicatorShortName                                  
+#>         <int> <chr>         <chr>                                               
+#> 1           1 CVDP001AF     AF: Prevalence (CVDP001AF)                          
+#> 2           2 CVDP002HYP    Hypertension: Treated to appropriate threshold (age…
+#> 3           3 CVDP003HYP    Hypertension: Treated to appropriate threshold (age…
+#> 4           4 CVDP004HYP    Hypertension: BP monitoring (CVDP004HYP)
 ```
 
 Typical outputs are [tibble](https://tibble.tidyverse.org/)s, making

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,4 +2,4 @@
 
 0 errors | 0 warnings | 1 note
 
-* This update removes all internet access during examples, tests, and vignettes to comply with CRAN policies.
+* This update switches to in-memory cache creation when running non-interactively to address issues detected by CRAN checks.


### PR DESCRIPTION
closes #23 

# Changes
- Increments version number to v.0.2.4
- Makes `cvd_clear_cache()` available for users to clear the cache
- Corrects an error in README
- Ensures the package switches to in-memory cache when run non-interactively (i.e. on CRAN)