### PR TITLE
:lipstick: Better organisation of articles

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,21 @@
 url: https://craig-parylo.github.io/cvdprevent/
 template:
   bootstrap: 5
+
+articles:
+  - title: "📖 Reference"
+    navbar: "📖 Reference"
+    desc: "Backgoround concepts and function reference guides."
+    contents:
+      - articles/key_terms
+      - articles/functions_by_argument
+  - title: "🚀 Guides"
+    navbar: "🚀 Guides"
+    desc: "Step-by-step tutorials and applied workflows."
+    contents:
+      - using_cvdprevent
+      - articles/example_workflows
+
 reference:
   - title: "📅 Time periods"
     desc: >

--- a/vignettes/articles/functions_by_argument.Rmd
+++ b/vignettes/articles/functions_by_argument.Rmd
@@ -71,7 +71,7 @@ get_tibble_of_arguments_and_their_functions <- function(pkg = "cvdprevent") {
 
 ```
 
-This article provides an interactive index of the exported functions in **cvdprevent**, grouped by their arguments. The searchable table makes it easy to see whcih functions share common parameters and to jump directly to their documentation.
+This article provides an interactive index of the exported functions in **cvdprevent**, grouped by their arguments. The searchable table makes it easy to see which functions share common parameters and to jump directly to their documentation.
 
 ```{r setup}
 #| echo: false


### PR DESCRIPTION
closes #30 

This PR reorganises the articles listed in the pkgdown site's navbar dropdown to improve navigation and usability.

Articles are now grouped into two clear sections: 

- **Reference:** background concepts and function reference guides,
- **Guides:** step-by-step tutorials and applied workflows.

This restructuring makes it easier for users to locate the resource they need, whether they're looking for conceptual background or practical guidance.